### PR TITLE
Updated xdebug and redis versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ As of now, we have several different PHP versions. Use appropriate php version a
 - 7.4.x
 - 8.0.x
 - 8.1.x
+- 8.2.x
 
 ## Installation
 

--- a/bin/php82/Dockerfile
+++ b/bin/php82/Dockerfile
@@ -36,12 +36,12 @@ openssl && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Install xdebug
-RUN pecl install xdebug-3.1.4 && \
+RUN pecl install xdebug-3.2.1 && \
     docker-php-ext-enable xdebug && \
     mkdir /var/log/xdebug
 
 # Install redis
-RUN pecl install redis-5.3.3 && \
+RUN pecl install redis-5.3.7 && \
     docker-php-ext-enable redis
 
 # Install imagick


### PR DESCRIPTION
Updated xdebug and redis versions which are compatible with PHP 8.2
Also added PHP 8.2.x in README file.